### PR TITLE
Renames prepare for teleop to flush

### DIFF
--- a/robot/autonomous/base_auto.py
+++ b/robot/autonomous/base_auto.py
@@ -13,5 +13,6 @@ class VictisAuto(StatefulAutonomous):
         
     @state
     def done(self):
-        self.drive.prepare_for_teleop()
+        self.drive.flush()
+        super().done()
         

--- a/robot/components/swervedrive.py
+++ b/robot/components/swervedrive.py
@@ -132,7 +132,7 @@ class SwerveDrive:
                 data[key] = data[key] / maxMagnitude
         return data
     
-    def prepare_for_teleop(self):
+    def flush(self):
         self._requested_vectors = {
                 'fwd': 0,
                 'strafe': 0,
@@ -154,7 +154,7 @@ class SwerveDrive:
         }
         
         for module in self.modules.values():
-            module.prepare_for_teleop()
+            module.flush()
         
     
     def enable_position_prediction(self, zero_position = True):

--- a/robot/components/swervemodule.py
+++ b/robot/components/swervemodule.py
@@ -89,7 +89,7 @@ class SwerveModule:
         
         self.drive_encoder_zero = self.driveMotor.getPosition()
     
-    def prepare_for_teleop(self):
+    def flush(self):
         self._requested_voltage = self.encoder.getVoltage()
         self._requested_speed = 0
     

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -122,10 +122,11 @@ class MyRobot(magicbot.MagicRobot):
 
     def disabledInit(self):
         """Do once right away when robot is disabled."""
+        self.drive.flush()
 
     def teleopInit(self):
         """Do when teleoperated mode is started."""
-        self.drive.prepare_for_teleop() #This is a poor solution to the drive system maintain speed/direction
+        self.drive.flush() #This is a poor solution to the drive system maintain speed/direction
         
         self.drive._field_centric = True # Doesn't set the property becuase the property resets the navx
         self.drive.allow_reverse = False


### PR DESCRIPTION
This is a minor change but `prepare_for_teleop` was a bad name because this could be used in other places besides the beginning of teleop.